### PR TITLE
Reorder files

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ When called without any arguments Fix automatically goes into an interactive mod
      file add [fileName] - Adds a file to the current folder and project.
      file remove [fileName] - Removes a file from the current folder and project.
      file list - List all files of the current project.
+	 file order [file1] [file2] - orders `file1` immediately before `file2` in the project.
      reference add [reference] - Add a reference to the current project.
      reference remove [reference] - Remove a reference from the current project.
      reference list - List all references of the current project.

--- a/src/Fix/Program.fs
+++ b/src/Fix/Program.fs
@@ -118,6 +118,16 @@ let file fileName f =
         let project = promptList ()
         f fileName project node
 
+let Order file1 file2 =
+    let orderFiles project = alterProject project (fun x -> x.OrderFiles file1 file2)
+
+    match getProjects() with
+    | [| project |] -> orderFiles project.Name
+    | [||] -> promptNoProjectFound()
+    | _ ->
+        let project = promptList ()
+        orderFiles project
+
 let Add fileName =
     file fileName addFileToProject
     Path.Combine(directory, fileName) |> Fake.FileHelper.CreateFile
@@ -257,6 +267,7 @@ let handleInput = function
     | [ "file"; "add"; fileName ] -> Add fileName; 0
     | [ "file"; "remove"; fileName ] -> Remove fileName; 0
     | [ "file"; "list"] -> ListFiles(); 0
+    | [ "file"; "order"; file1; file2 ] -> Order file1 file2; 0
     | [ "reference"; "add"; fileName ] -> AddReference fileName; 0
     | [ "reference"; "remove"; fileName ] -> RemoveReference fileName; 0
     | [ "reference"; "list"] -> ListReference(); 0

--- a/src/Fix/Program.fs
+++ b/src/Fix/Program.fs
@@ -217,7 +217,7 @@ let Help () =
           \n                    - Removes the filename from disk and the project.\
           \n                      If more than one project is in the current\
           \n                      directory you will be prompted which to use.\n\
-            file list           - List all files
+            file list           - List all files\n\
             reference add [reference]\
           \n                    - Add reference to the current project.\
           \n                      If more than one project is in the current\

--- a/src/Fix/Program.fs
+++ b/src/Fix/Program.fs
@@ -234,6 +234,10 @@ let Help () =
           \n                      If more than one project is in the current\
           \n                      directory you will be prompted which to use.\n\
             file list           - List all files\n\
+            file order [file1] [file2]\
+          \n                    - Moves file1 immediately before file2 in the project.
+          \n                      If more than one project is in the current\
+          \n                      directory you will be prompted which to use.\n\
             reference add [reference]\
           \n                    - Add reference to the current project.\
           \n                      If more than one project is in the current\

--- a/src/Fix/Program.fs
+++ b/src/Fix/Program.fs
@@ -29,7 +29,7 @@ let RefreshTemplates () =
 let applicationNameToProjectName folder projectName =
     let applicationName = "ApplicationName"
     let files = Directory.GetFiles folder |> Seq.where (fun x -> x.Contains applicationName)
-    files |> Seq.iter (fun x -> File.Copy(x, x.Replace(applicationName, projectName)))
+    files |> Seq.iter (fun x -> File.Move(x, x.Replace(applicationName, projectName)))
 
 let copyPaket folder =
     folder </> ".paket" |> Directory.CreateDirectory |> ignore
@@ -69,7 +69,7 @@ let promptProjectDir () =
     Console.Write("> ")
     Console.ReadLine()
 
-let promptList () =
+let promptTemplates () =
     printfn "Choose a template:"
     let templates = Directory.GetDirectories(templatesLocation)
                     |> Seq.map Path.GetFileName
@@ -79,6 +79,12 @@ let promptList () =
     Console.Write("> ")
     Console.ReadLine()
 
+let promptSelect list =
+    printfn "Choose one:"
+    list |> Seq.iter (fun x -> printfn " - %s" x)
+    printfn ""
+    Console.Write("> ")
+    Console.ReadLine()
 
 let alterProject project (f : ProjectFile -> ProjectFile) =
     let fsProj = ProjectFile.FromFile(project)
@@ -114,8 +120,8 @@ let file fileName f =
     match getProjects() with
     | [| project |] -> f fileName project.Name node
     | [||] -> promptNoProjectFound()
-    | _ ->
-        let project = promptList ()
+    | projects ->
+        let project = projects |> Seq.map (fun x -> x.Name) |> promptSelect
         f fileName project node
 
 let Order file1 file2 =
@@ -124,8 +130,8 @@ let Order file1 file2 =
     match getProjects() with
     | [| project |] -> orderFiles project.Name
     | [||] -> promptNoProjectFound()
-    | _ ->
-        let project = promptList ()
+    | projects ->
+        let project = projects |> Seq.map (fun x -> x.Name) |> promptSelect
         orderFiles project
 
 let Add fileName =
@@ -136,8 +142,8 @@ let executeForProject exec =
     match getProjects() with
     | [| project |] -> exec project.Name
     | [||] -> promptNoProjectFound()
-    | _ ->
-        let project = promptList ()
+    | projects ->
+        let project = projects |> Seq.map (fun x -> x.Name) |> promptSelect
         exec project
 
 let AddReference reference =
@@ -195,7 +201,7 @@ let New projectName projectDir templateName paket =
 
     let projectName' = if String.IsNullOrWhiteSpace projectName then promptProjectName () else projectName
     let projectDir' = if String.IsNullOrWhiteSpace projectDir then promptProjectDir () else projectDir
-    let templateName' = if String.IsNullOrWhiteSpace templateName then promptList () else templateName
+    let templateName' = if String.IsNullOrWhiteSpace templateName then promptTemplates () else templateName
     let projectFolder = directory </> projectDir' </> projectName'
     let templateDir = templatesLocation </> templateName'
 

--- a/src/Fix/ProjectSystem.fs
+++ b/src/Fix/ProjectSystem.fs
@@ -36,6 +36,7 @@ type ProjectFile(projectFileName:string,documentContent : string) =
         let newNode = newElement document nodeType
         newNode.SetAttribute("Include", fileName)
 
+        //get the first ItemGroup node
         let itemGroup = getNodes xPath document |> List.map(fun x -> x.ParentNode) |> List.distinct |> List.tryHead
 
         match itemGroup with
@@ -48,18 +49,36 @@ type ProjectFile(projectFileName:string,documentContent : string) =
 
         new ProjectFile(projectFileName,document.OuterXml)
 
+    let getNode document xPath fileName =
+        getNodes xPath document
+        |> List.filter (fun node -> getFileAttribute node = fileName)
+        |> Seq.tryLast
+
     let removeFile fileName xPath =
         let document = XMLDoc documentContent // we create a copy and work immutable
-        let node =
-            getNodes xPath document
-            |> List.filter (fun node -> getFileAttribute node = fileName)
-            |> Seq.tryLast  // we remove the last one to make easier to remove duplicates
+        let node = getNode document xPath fileName
 
         match node with
         | Some n -> n.ParentNode.RemoveChild n |> ignore
         | None -> ()
 
         new ProjectFile(projectFileName,document.OuterXml)
+
+    let orderFiles fileName1 fileName2 xPath =
+        let document = XMLDoc documentContent // we create a copy and work immutable
+        match getNode document xPath fileName1 with
+        | Some n1 -> 
+            let updated = removeFile fileName1 xPath
+            let updatedXml = XMLDoc updated.Content
+            match getNode updatedXml xPath fileName2 with
+            | Some n2 -> 
+                let node = updatedXml.CreateElement(n1.Name, n1.LocalName, n1.NamespaceURI)
+                n2.ParentNode.InsertBefore(node, n2) |> ignore
+
+                new ProjectFile(projectFileName, updatedXml.OuterXml)
+
+            | None -> new ProjectFile(projectFileName,document.OuterXml)
+        | _ -> new ProjectFile(projectFileName,document.OuterXml)
 
     /// Read a Project from a FileName
     static member FromFile(projectFileName) = new ProjectFile(projectFileName,ReadFileAsString projectFileName)
@@ -112,6 +131,7 @@ type ProjectFile(projectFileName:string,documentContent : string) =
 
     /// Places the first file above the second file
     member x.OrderFiles file1 file2 =
+        orderFiles file1 file2 projectFilesXPath
         
 
     /// The project file name

--- a/src/Fix/ProjectSystem.fs
+++ b/src/Fix/ProjectSystem.fs
@@ -72,7 +72,8 @@ type ProjectFile(projectFileName:string,documentContent : string) =
             let updatedXml = XMLDoc updated.Content
             match getNode updatedXml xPath fileName2 with
             | Some n2 -> 
-                let node = updatedXml.CreateElement(n1.Name, n1.LocalName, n1.NamespaceURI)
+                let node = newElement updatedXml n1.Name
+                node.SetAttribute("Include", fileName1)
                 n2.ParentNode.InsertBefore(node, n2) |> ignore
 
                 new ProjectFile(projectFileName, updatedXml.OuterXml)

--- a/src/Fix/ProjectSystem.fs
+++ b/src/Fix/ProjectSystem.fs
@@ -110,6 +110,10 @@ type ProjectFile(projectFileName:string,documentContent : string) =
         x.FindDuplicateFiles()
         |> List.fold (fun (project:ProjectFile) duplicate -> project.RemoveFile duplicate) x
 
+    /// Places the first file above the second file
+    member x.OrderFiles file1 file2 =
+        
+
     /// The project file name
     member x.ProjectFileName = projectFileName
 

--- a/tests/Fix.Tests/Tests.fs
+++ b/tests/Fix.Tests/Tests.fs
@@ -123,3 +123,9 @@ let ``Reorder files in project - content``() =
 </Project>"""
 
     projectContent |> shouldbetext expectedContent
+
+[<Test>]
+let ``Reorder files does nothing if one of the files isn't found``() =
+    let projectFile = new ProjectFile("foo.fsproj", projectWithFiles)
+    let changedProjectFile = projectFile.OrderFiles  "404.fs" "FixProject.fs"
+    Assert.AreEqual(projectFile.Content, changedProjectFile.Content)

--- a/tests/Fix.Tests/Tests.fs
+++ b/tests/Fix.Tests/Tests.fs
@@ -90,3 +90,36 @@ let ``Remove non existing file from Project - file count``() =
     let changedProjectFile = projectFile.RemoveFile "FixProject.fs"
     let files = changedProjectFile.ProjectFiles |> Seq.length
     Assert.AreEqual(0, files)
+
+
+[<Test>]
+let ``Reorder files in project - file count``() =
+    let projectFile = new ProjectFile("foo.fsproj", projectWithFiles)
+    let changedProjectFile = projectFile.OrderFiles  "a_file.fs" "FixProject.fs"
+    Assert.AreEqual(projectFile.ProjectFiles |> Seq.length, changedProjectFile.ProjectFiles |> Seq.length)
+
+[<Test>]
+let ``Reorder files in project - content``() =
+    let projectFile = new ProjectFile("foo.fsproj", projectWithFiles)
+    let changedProjectFile = projectFile.OrderFiles  "a_file.fs" "FixProject.fs"
+    let projectContent = changedProjectFile.Content
+
+    let expectedContent = """<?xml version="1.0" encoding="utf-16"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="a_file.fs" />
+    <Compile Include="FixProject.fs" />
+    <None Include="App.config" />
+  </ItemGroup>
+</Project>"""
+
+    projectContent |> shouldbetext expectedContent


### PR DESCRIPTION
most of the changes are additions, but line 32 in Program.fs has been changed from `Copy` to `Move`.   @Krzysztof-Cieslak looks like you changed that from `Move` to `Copy` but in my testing that keeps the template files so I end up with a folder structure that contains `ApplicationName.fsproj` and `MyProjectName.fsproj`.  