### PR TITLE
Ensure fsproj's UTF-8 encoding is kept when persisted

### DIFF
--- a/src/Fix/ProjectSystem.fs
+++ b/src/Fix/ProjectSystem.fs
@@ -67,11 +67,11 @@ type ProjectFile(projectFileName:string,documentContent : string) =
     let orderFiles fileName1 fileName2 xPath =
         let document = XMLDoc documentContent // we create a copy and work immutable
         match getNode document xPath fileName1 with
-        | Some n1 -> 
+        | Some n1 ->
             let updated = removeFile fileName1 xPath
             let updatedXml = XMLDoc updated.Content
             match getNode updatedXml xPath fileName2 with
-            | Some n2 -> 
+            | Some n2 ->
                 let node = newElement updatedXml n1.Name
                 node.SetAttribute("Include", fileName1)
                 n2.ParentNode.InsertBefore(node, n2) |> ignore
@@ -85,7 +85,11 @@ type ProjectFile(projectFileName:string,documentContent : string) =
     static member FromFile(projectFileName) = new ProjectFile(projectFileName,ReadFileAsString projectFileName)
 
     /// Saves the project file
-    member x.Save(?fileName) = document.Save(defaultArg fileName projectFileName)
+    member x.Save(?fileName) =
+        use writer = new System.IO.StreamWriter(defaultArg fileName projectFileName,
+                                                false,
+                                                new System.Text.UTF8Encoding(false))
+        document.Save(writer)
 
     member x.Content =
         use stringWriter = new System.IO.StringWriter()
@@ -133,7 +137,7 @@ type ProjectFile(projectFileName:string,documentContent : string) =
     /// Places the first file above the second file
     member x.OrderFiles file1 file2 =
         orderFiles file1 file2 projectFilesXPath
-        
+
 
     /// The project file name
     member x.ProjectFileName = projectFileName

--- a/src/Fix/ProjectSystem.fs
+++ b/src/Fix/ProjectSystem.fs
@@ -92,9 +92,14 @@ type ProjectFile(projectFileName:string,documentContent : string) =
         document.Save(writer)
 
     member x.Content =
-        use stringWriter = new System.IO.StringWriter()
-        document.Save(stringWriter)
-        stringWriter.ToString()
+        let utf8 = new System.Text.UTF8Encoding(false)
+        let settings = new XmlWriterSettings()
+        settings.Encoding <- utf8
+        settings.Indent <- true
+        use ms = new System.IO.MemoryStream()
+        use writer = System.Xml.XmlWriter.Create(ms, settings)
+        document.Save(writer)
+        ms.GetBuffer() |> utf8.GetString
 
 
 

--- a/tests/Fix.Tests/ReferenceTests.fs
+++ b/tests/Fix.Tests/ReferenceTests.fs
@@ -39,7 +39,7 @@ let ``Add reference to project - only references - content``() =
 
     let projectContent = changedProjectFile.Content
 
-    let expectedContent = """<?xml version="1.0" encoding="utf-16"?>
+    let expectedContent = """<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Reference Include="mscorlib" />
@@ -63,7 +63,7 @@ let ``Add reference to project - content``() =
 
     let projectContent = changedProjectFile.Content
 
-    let expectedContent = """<?xml version="1.0" encoding="utf-16"?>
+    let expectedContent = """<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Reference Include="mscorlib" />
@@ -97,7 +97,7 @@ let ``Remove reference from project - only references - content``() =
 
     let projectContent = changedProjectFile.Content
 
-    let expectedContent = """<?xml version="1.0" encoding="utf-16"?>
+    let expectedContent = """<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Reference Include="mscorlib" />
@@ -119,7 +119,7 @@ let ``Remove reference from project - content``() =
 
     let projectContent = changedProjectFile.Content
 
-    let expectedContent = """<?xml version="1.0" encoding="utf-16"?>
+    let expectedContent = """<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Reference Include="mscorlib" />

--- a/tests/Fix.Tests/Tests.fs
+++ b/tests/Fix.Tests/Tests.fs
@@ -32,7 +32,7 @@ let ``Add file works even if ItemGroup not found - file content`` () =
     let newProject = projectFile.AddFile "file.fs" "Compile"
     let projectContent = newProject.Content
 
-    let expectedContent = """<?xml version="1.0" encoding="utf-16"?>
+    let expectedContent = """<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Reference Include="mscorlib" />
@@ -64,7 +64,7 @@ let ``Remove file from Project - content``() =
     let changedProjectFile = projectFile.RemoveFile "FixProject.fs"
     let projectContent = changedProjectFile.Content
 
-    let expectedContent = """<?xml version="1.0" encoding="utf-16"?>
+    let expectedContent = """<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Reference Include="mscorlib" />
@@ -104,7 +104,7 @@ let ``Reorder files in project - content``() =
     let changedProjectFile = projectFile.OrderFiles  "a_file.fs" "FixProject.fs"
     let projectContent = changedProjectFile.Content
 
-    let expectedContent = """<?xml version="1.0" encoding="utf-16"?>
+    let expectedContent = """<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Reference Include="mscorlib" />


### PR DESCRIPTION
Currently when modifying fsproject files it gets re-encoded in UTF-16 since that is the .NET default for strings.   XmlDocument.Save(filename: string) triggers this as it utilizes a String[Writer/Builder].