### PR TITLE
Run local tools installation if present

### DIFF
--- a/src/Fix/Fake.fs
+++ b/src/Fix/Fake.fs
@@ -12,6 +12,11 @@ let Copy folder =
         let fn = (folder </> Path.GetFileName x)
         if not ^ File.Exists fn then File.Copy (x, fn) )
 
+let getFAKE () =
+    match Directory.EnumerateFiles(directory, "FAKE.exe", SearchOption.AllDirectories) |> Seq.tryHead with
+    | Some f -> f
+    | None -> fakeToolLocation </> "FAKE.exe"
+
 let Update () =
     use wc = new WebClient()
     let zip = fakeLocation </> "fake.zip"
@@ -21,7 +26,7 @@ let Update () =
     Fake.ZipHelper.Unzip fakeLocation zip
 
 let Run args =
-    let f = fakeToolLocation </> "FAKE.exe"
+    let f = getFAKE ()
     if not ^ File.Exists f then Update ()
     let args' = args |> String.concat " "
     run f args' directory

--- a/src/Fix/Paket.fs
+++ b/src/Fix/Paket.fs
@@ -6,6 +6,15 @@ open Common
 
 let location = templatesLocation </> ".paket"
 
+let getPaketLocation () =
+    let local = directory </> ".paket"
+    if Directory.Exists local then local else paketLocation
+
+let getPaket () =
+    let local = directory </> ".paket" </> "paket.exe"
+    if File.Exists local then local else paketLocation </> "paket.exe"
+
+
 let Copy folder =
     folder </> ".paket" |> Directory.CreateDirectory |> ignore
     Directory.GetFiles location
@@ -14,10 +23,11 @@ let Copy folder =
         File.Copy (x, folder </> ".paket" </> fn, true) )
 
 let Update () =
-    run (paketLocation </> "paket.bootstrapper.exe") "" paketLocation
+    let f = getPaketLocation ()
+    run (f </> "paket.bootstrapper.exe") "" f
 
 let Run args =
-    let f = paketLocation </> "paket.exe"
+    let f = getPaket ()
     if not ^ File.Exists f then Update ()
     let args' = args |> String.concat " "
     run f args' directory


### PR DESCRIPTION
Idea is to use local installations of Paket and FAKE if they are present in solution, fallback to global version (deployed with Fix) otherwise.

It would ensure that for projects already using Paket and FAKE we will use exact same version as is necessary.

- [X] Paket
- [x] FAKE