### PR TITLE
Ensure just LF for build.sh. Fixes #35

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -23,3 +23,6 @@
 *.PDF diff=astextplain
 *.rtf diff=astextplain
 *.RTF diff=astextplain
+
+# Ensure that build.sh keeps LF instead of CRLF
+build.sh eol=lf


### PR DESCRIPTION
Add a rule to .gitattributes to ensure that whenever `build.sh` is committed, it gets pushed up with LF instead of CRLF.

Oddly, on my machine it looked like `build.sh` was already LF instead of CRLF, but that's probably because I checked it out on a Linux machine and the default behavior was "match the current platform".